### PR TITLE
Refactor search bar to avoid hardcoded padding

### DIFF
--- a/src/app/pages/app-bar/search-bar/search-bar.component.html
+++ b/src/app/pages/app-bar/search-bar/search-bar.component.html
@@ -1,32 +1,30 @@
-<mat-toolbar color="primary" class="main-header mat-elevation-z4" [class.hidden]="toggleSearch">
-    <mat-toolbar-row>
-        <button mat-icon-button *ngIf="isSmall" (click)="toggleMenu()" style="margin-left: -8px;">
-            <mat-icon>menu</mat-icon>
-        </button>
-        <div class="mat-title">Search Bar</div>
-        <pxb-spacer></pxb-spacer>
-        <button mat-icon-button (click)="openSearch()">
-            <mat-icon>search</mat-icon>
-        </button>
-    </mat-toolbar-row>
-</mat-toolbar>
-
-<mat-toolbar
-    class="search-block mat-elevation-z4"
-    [class.active]="toggleSearch"
-    [style.paddingLeft]="isSmall || !toggleSearch ? '0' : '270px'"
->
-    <mat-toolbar-row style="padding: 0 5px;">
-        <button class="search-icon" mat-icon-button disabled>
-            <mat-icon>search</mat-icon>
-        </button>
-        <input class="search-control" type="text" placeholder="Search" [(ngModel)]="searchText" #searchBar />
-        <button mat-icon-button (click)="searchClose()" style="margin-right: 8px;">
-            <mat-icon [style.color]="Colors.black[500]">close</mat-icon>
-        </button>
-    </mat-toolbar-row>
-</mat-toolbar>
-
+<div class="mat-elevation-z4 toolbar-container">
+    <mat-toolbar></mat-toolbar>
+    <!-- This is here as a placeholder to maintain the header height with absolute positioned children -->
+    <mat-toolbar color="primary" class="main-header" [class.hidden]="toggleSearch">
+        <mat-toolbar-row>
+            <button mat-icon-button *ngIf="isSmall" (click)="toggleMenu()" style="margin-left: -8px;">
+                <mat-icon>menu</mat-icon>
+            </button>
+            <div class="mat-title">Search Bar</div>
+            <pxb-spacer></pxb-spacer>
+            <button mat-icon-button (click)="openSearch()">
+                <mat-icon>search</mat-icon>
+            </button>
+        </mat-toolbar-row>
+    </mat-toolbar>
+    <mat-toolbar class="search-header" [class.active]="toggleSearch">
+        <mat-toolbar-row style="padding: 0 5px;">
+            <button class="search-icon" mat-icon-button disabled>
+                <mat-icon>search</mat-icon>
+            </button>
+            <input class="search-control" type="text" placeholder="Search" [(ngModel)]="searchText" #searchBar />
+            <button mat-icon-button (click)="searchClose()" style="margin-right: 8px;">
+                <mat-icon [style.color]="Colors.black[500]">close</mat-icon>
+            </button>
+        </mat-toolbar-row>
+    </mat-toolbar>
+</div>
 <mat-list>
     <pxb-info-list-item *ngFor="let item of list | filter: searchText">
         <mat-icon pxb-icon>person</mat-icon>

--- a/src/app/pages/app-bar/search-bar/search-bar.component.html
+++ b/src/app/pages/app-bar/search-bar/search-bar.component.html
@@ -1,6 +1,4 @@
 <div class="mat-elevation-z4 toolbar-container">
-    <mat-toolbar></mat-toolbar>
-    <!-- This is here as a placeholder to maintain the header height with absolute positioned children -->
     <mat-toolbar color="primary" class="main-header" [class.hidden]="toggleSearch">
         <mat-toolbar-row>
             <button mat-icon-button *ngIf="isSmall" (click)="toggleMenu()" style="margin-left: -8px;">

--- a/src/app/pages/app-bar/search-bar/search-bar.component.html
+++ b/src/app/pages/app-bar/search-bar/search-bar.component.html
@@ -1,4 +1,4 @@
-<div class="mat-elevation-z4 toolbar-container">
+<div class="mat-elevation-z4 toolbar-container" [style.backgroundColor]="Colors.white[50]">
     <mat-toolbar color="primary" class="main-header" [class.hidden]="toggleSearch">
         <mat-toolbar-row>
             <button mat-icon-button *ngIf="isSmall" (click)="toggleMenu()" style="margin-left: -8px;">

--- a/src/app/pages/app-bar/search-bar/search-bar.component.scss
+++ b/src/app/pages/app-bar/search-bar/search-bar.component.scss
@@ -1,3 +1,5 @@
+@import '~@pxblue/colors/palette.scss';
+
 .toolbar-container {
     position: sticky;
     z-index: 1000;
@@ -16,7 +18,7 @@
     top: 0;
     right: 0;
     width: 0%;
-    background: #fff;
+    background: map-get($pxb-white, 50);
     transition: width 250ms ease-in-out;
 
     &.active {

--- a/src/app/pages/app-bar/search-bar/search-bar.component.scss
+++ b/src/app/pages/app-bar/search-bar/search-bar.component.scss
@@ -1,12 +1,9 @@
 .toolbar-container {
     position: sticky;
     z-index: 1000;
+    top: 0;
 }
 .main-header {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
     transition: opacity 250ms ease-in-out;
 
     &.hidden {

--- a/src/app/pages/app-bar/search-bar/search-bar.component.scss
+++ b/src/app/pages/app-bar/search-bar/search-bar.component.scss
@@ -1,27 +1,26 @@
-header {
-    position: fixed;
-    top: 0;
-    z-index: 11;
-    transition: all 250ms ease-in-out;
-}
-
-.main-header {
-    @extend header;
+.toolbar-container {
     position: sticky;
-    top: 0;
     z-index: 1000;
+}
+.main-header {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    transition: opacity 250ms ease-in-out;
 
     &.hidden {
         opacity: 0;
     }
 }
 
-.search-block {
-    width: 0%;
+.search-header {
+    position: absolute;
+    top: 0;
     right: 0;
-    z-index: 1000;
-    @extend header;
+    width: 0%;
     background: #fff;
+    transition: width 250ms ease-in-out;
 
     &.active {
         width: 100%;

--- a/src/app/pages/app-bar/search-bar/search-bar.component.ts
+++ b/src/app/pages/app-bar/search-bar/search-bar.component.ts
@@ -36,7 +36,8 @@ export class SearchBarComponent implements OnInit {
 
     openSearch(): void {
         this.toggleSearch = true;
-        this.searchBar.nativeElement.focus();
+        // focus the input after the animation completes to avoid a jerky transition
+        setTimeout(() => this.searchBar.nativeElement.focus(), 250);
     }
 
     searchClose(): void {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,16 @@
         "moduleResolution": "node",
         "importHelpers": true,
         "target": "es2015",
-        "lib": ["es2018", "dom"]
+        "lib": [
+            "es2018",
+            "dom"
+        ]
     },
     "angularCompilerOptions": {
         "fullTemplateTypeCheck": true,
         "strictInjectionParameters": true
-    }
+    },
+    "exclude": [
+        "**/*spec.ts"
+    ]
 }


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Refactor search bar to avoid hardcoded left padding
- Uses a sticky positioned wrapper to contain both (absolutely positioned) headers
-Updated tsconfig.json to clean up some console warnings

Doing it this way will allow it to work more seamlessly with multiple variants of the drawer (particularly the persistent).