### PR TITLE
Use sticky cancel button

### DIFF
--- a/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.html
+++ b/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.html
@@ -16,8 +16,9 @@
             </a>
         </div>
     </div>
+    <mat-divider></mat-divider>
     <div class="footer-list" data-cy="btm-sheet-show">
-        <h3>Show:</h3>
+        <h3>Show</h3>
         <div fxLayout="row wrap" fxLayoutAlign="center center">
             <a
                 data-cy="active-alarms"
@@ -59,7 +60,7 @@
         </div>
     </div>
 
-    <div class="footer-close" data-cy="btm-sheet-close">
+    <div class="footer-close mat-elevation-z8" data-cy="btm-sheet-close">
         <a mat-list-item (click)="openLink()" style="text-align: left;">
             <mat-icon data-cy="btm-sheet-close-btn" mat-list-icon>close</mat-icon>
             <span mat-line>Close</span>

--- a/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.html
+++ b/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.html
@@ -59,7 +59,7 @@
             </a>
         </div>
     </div>
-
+    <mat-divider class="on-wide-screen"></mat-divider>
     <div class="footer-close mat-elevation-z8" data-cy="btm-sheet-close">
         <a mat-list-item (click)="openLink()" style="text-align: left;">
             <mat-icon data-cy="btm-sheet-close-btn" mat-list-icon>close</mat-icon>

--- a/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.html
+++ b/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.html
@@ -1,6 +1,6 @@
 <mat-nav-list>
     <div class="footer-list" data-cy="btm-sheet-sort">
-        <h3>Sort by</h3>
+        <h3 class="mat-overline">Sort by</h3>
         <div fxLayout="row wrap" fxLayoutAlign="center center">
             <a [class.active]="activeSort == filterTypes.TIME" (click)="sortData(filterTypes?.TIME)">
                 <button mat-icon-button>
@@ -18,7 +18,7 @@
     </div>
     <mat-divider></mat-divider>
     <div class="footer-list" data-cy="btm-sheet-show">
-        <h3>Show</h3>
+        <h3 class="mat-overline">Show</h3>
         <div fxLayout="row wrap" fxLayoutAlign="center center">
             <a
                 data-cy="active-alarms"
@@ -59,11 +59,11 @@
             </a>
         </div>
     </div>
-    <mat-divider class="on-wide-screen"></mat-divider>
     <div class="footer-close mat-elevation-z8" data-cy="btm-sheet-close">
-        <a mat-list-item (click)="openLink()" style="text-align: left;">
-            <mat-icon data-cy="btm-sheet-close-btn" mat-list-icon>close</mat-icon>
-            <span mat-line>Close</span>
-        </a>
+        <mat-divider class="on-wide-screen"></mat-divider>
+        <pxb-info-list-item [dense]="true" (click)="openLink()">
+            <mat-icon pxb-icon data-cy="btm-sheet-close-btn" mat-list-icon>close</mat-icon>
+            <div pxb-title>Close</div>
+        </pxb-info-list-item>
     </div>
 </mat-nav-list>

--- a/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.scss
+++ b/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.scss
@@ -18,14 +18,6 @@
     .footer-list {
         padding: 16px;
     }
-    h3 {
-        margin: 0;
-        text-transform: uppercase;
-        color: #424e54;
-        font-size: 12px;
-        letter-spacing: 2px;
-        font-weight: 600;
-    }
     .footer-close {
         position: sticky;
         bottom: 0;

--- a/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.scss
+++ b/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.scss
@@ -3,6 +3,7 @@
     width: 100%;
     max-width: 600px;
     padding: 0;
+    max-height: unset;
     .mat-nav-list {
         padding: 0;
     }
@@ -16,10 +17,14 @@
     }
     .footer-list {
         padding: 15px;
-        border-bottom: 1px solid #ccc;
     }
     h3 {
         margin: 0;
+    }
+    .footer-close {
+        position: sticky;
+        bottom: 0;
+        background-color: white;
     }
 }
 

--- a/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.scss
+++ b/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.scss
@@ -8,7 +8,7 @@
         padding: 0;
     }
     a {
-        padding: 10px;
+        padding: 8px;
         cursor: pointer;
         text-align: center;
         &.active {
@@ -16,10 +16,15 @@
         }
     }
     .footer-list {
-        padding: 15px;
+        padding: 16px;
     }
     h3 {
         margin: 0;
+        text-transform: uppercase;
+        color: #424e54;
+        font-size: 12px;
+        letter-spacing: 2px;
+        font-weight: 600;
     }
     .footer-close {
         position: sticky;
@@ -36,5 +41,14 @@
             text-overflow: inherit;
             white-space: normal;
         }
+    }
+    .on-wide-screen {
+        display: none;
+    }
+}
+
+@media (min-width: 601px) {
+    .footer-close.mat-elevation-z8 {
+        box-shadow: unset;
     }
 }

--- a/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.ts
+++ b/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.ts
@@ -57,7 +57,15 @@ export class BottomSheet implements OnInit {
 }
 
 @NgModule({
-    imports: [CommonModule, MatIconModule, MatListModule, InfoListItemModule, MatButtonModule, FlexLayoutModule],
+    imports: [
+        CommonModule,
+        MatIconModule,
+        MatListModule,
+        InfoListItemModule,
+        MatButtonModule,
+        FlexLayoutModule,
+        MatDividerModule,
+    ],
     declarations: [],
     providers: [],
 })

--- a/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.ts
+++ b/src/app/pages/overlays/complex-bottom-sheet/bottom-sheet/bottom-sheet.ts
@@ -2,6 +2,7 @@ import { Component, ViewEncapsulation, NgModule, OnInit } from '@angular/core';
 import { MatBottomSheetRef } from '@angular/material/bottom-sheet';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
+import { MatDividerModule } from '@angular/material/divider';
 import { CommonModule } from '@angular/common';
 import { InfoListItemModule } from '@pxblue/angular-components';
 import { DataService } from '../data.service';


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Partially fixes #30, haven't checked React side yet.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Pin the cancel row on the bottom using elevation
- Tweaked some design

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
Desktop (same style as before, but note how I used overline font in place of the h3): 
![image](https://user-images.githubusercontent.com/8997218/90969628-94d80a80-e4c8-11ea-92cc-9ca6d0f21947.png)

Portrait mode with width less than 600:
![image](https://user-images.githubusercontent.com/8997218/90969634-b20cd900-e4c8-11ea-84d1-28f3b2b16c77.png)

Landscape mode, bottomsheet scrollable (according to what I see in the Gmail client app, I suppose it is OK to go full screen for the bottom sheet, as long as the cancel button is easily accessible).
![image](https://user-images.githubusercontent.com/8997218/90969639-c5b83f80-e4c8-11ea-8398-2e44bc02bc2b.png)
