### PR TITLE
Replace info list item with empty state component for searchbar example

### DIFF
--- a/src/app/pages/app-bar/search-bar/search-bar.component.html
+++ b/src/app/pages/app-bar/search-bar/search-bar.component.html
@@ -48,9 +48,9 @@
         <span pxb-subtitle>{{ item.party }}</span>
         <span pxb-info>{{ item.tookOffice }}</span>
     </pxb-info-list-item>
-    <pxb-info-list-item *ngIf="(list | filter: searchText).length === 0" data-cy="list-view-no-results">
-        <mat-icon pxb-icon>error</mat-icon>
-        <span pxb-title>0 results</span>
-        <span pxb-subtitle>No matching presidents</span>
-    </pxb-info-list-item>
 </mat-list>
+<div *ngIf="(list | filter: searchText).length === 0" style="height: calc(100vh - 64px)">
+    <pxb-empty-state title="0 Results" description="No matching presidents" style="margin: 16px">
+        <mat-icon pxb-empty-icon>error</mat-icon>
+    </pxb-empty-state>
+</div>

--- a/src/app/pages/app-bar/search-bar/search-bar.module.ts
+++ b/src/app/pages/app-bar/search-bar/search-bar.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { InfoListItemModule, SpacerModule } from '@pxblue/angular-components';
+import { EmptyStateModule, InfoListItemModule, SpacerModule } from '@pxblue/angular-components';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
@@ -21,6 +21,7 @@ import { FormsModule } from '@angular/forms';
         MatInputModule,
         MatFormFieldModule,
         FormsModule,
+        EmptyStateModule,
     ],
     declarations: [SearchBarComponent, FilterPipe],
 })


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #61.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Replace info list item with empty state component for searchbar example when there are no results.