### PR TITLE
fix mat-icon overriding css

### DIFF
--- a/src/app/pages/forms-and-validation/fix-length-passcode/fix-length-passcode.component.scss
+++ b/src/app/pages/forms-and-validation/fix-length-passcode/fix-length-passcode.component.scss
@@ -34,26 +34,26 @@ mat-form-field {
     }
 }
 .suffix-icons {
-    .spinner-container,
-    .icon-container {
+    .spinner-container.mat-icon,
+    .icon-container.mat-icon {
         display: none;
     }
 }
 .show-spinner {
-    .spinner-container {
+    .spinner-container.mat-icon {
         display: block;
         animation: fadeInAnimation $duration $animationTimingFunction;
     }
-    .icon-container {
+    .icon-container.mat-icon {
         display: none;
     }
 }
 
 .show-icon {
-    .spinner-container {
+    .spinner-container.mat-icon {
         display: none;
     }
-    .icon-container {
+    .icon-container.mat-icon {
         display: block;
         animation: fadeInAnimation $duration $animationTimingFunction;
     }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [155](https://github.com/pxblue/angular-design-patterns/issues/115) .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix CSS for hiding tick icon  when displaying loading icon

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/10433274/129882540-4e7f81b7-6d64-424e-91cc-ed7dabc525f3.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Test Local URL http://localhost:4200/forms-and-validation/fixed-length-passcode in mobile view
- Enter `123456` success passcode, it should display only spinner icon.
- After timeout spinner icon will hide and tick icon will show.
